### PR TITLE
fix(tests): Tests don't pass any children, crashing Library#render.

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -22,14 +22,14 @@ export default class Library extends React.Component {
           <Icon icon="economist" size="60px" uri="assets/icons.svg"
             className="library--economist-logo"
           />
-          {this.props.children.map((child) => {
+          {this.props.children ? this.props.children.map((child) => {
             return (
               <a href={`#${child.props.metadata.name}`}
                 className="library--sidebar-link"
                 key={`${child.props.metadata.name}-menu`}
               >{child.props.metadata.name.replace('@economist\/component-', '')}</a>
             );
-          })}
+          }) : null}
         </div>
         <div className="library--main" role="main">{this.props.children}</div>
       </div>


### PR DESCRIPTION
This fixes Library's tests by checking if `props.children` exists before mapping over it.